### PR TITLE
Improvements and bug fixes for Terraform 0.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: git://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.27.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,4 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
+      

--- a/README.md
+++ b/README.md
@@ -14,3 +14,72 @@ This Terraform module creates an AWS ECS Fargate task definition.
 Check versions for this module on:
 * Github Releases: <https://github.com/cn-terraform/terraform-aws-ecs-fargate-task-definition/releases>
 * Terraform Module Registry: <https://registry.terraform.io/modules/cn-terraform/ecs-fargate-task-definition/aws>
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| command | (Optional) The command that is passed to the container | `list(string)` | `null` | no |
+| container\_cpu | (Optional) The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of container\_cpu of all containers in a task will need to be lower than the task-level cpu value | `number` | `1024` | no |
+| container\_depends\_on | (Optional) The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed | <pre>list(object({<br>    containerName = string<br>    condition     = string<br>  }))</pre> | `null` | no |
+| container\_image | The image used to start the container. | `any` | n/a | yes |
+| container\_memory | (Optional) The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container\_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container\_memory of all containers in a task will need to be lower than the task memory value | `number` | `8192` | no |
+| container\_memory\_reservation | (Optional) The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container\_memory hard limit | `number` | `2048` | no |
+| container\_name | The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, \_ allowed) | `any` | n/a | yes |
+| dns\_servers | (Optional) Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers | `list(string)` | `null` | no |
+| docker\_labels | (Optional) The configuration options to send to the `docker_labels` | `map(string)` | `null` | no |
+| entrypoint | (Optional) The entry point that is passed to the container | `list(string)` | `null` | no |
+| environment | (Optional) The environment variables to pass to the container. This is a list of maps | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| essential | (Optional) Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `true` | no |
+| firelens\_configuration | (Optional) The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
+| healthcheck | (Optional) A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | <pre>object({<br>    command     = list(string)<br>    retries     = number<br>    timeout     = number<br>    interval    = number<br>    startPeriod = number<br>  })</pre> | `null` | no |
+| links | (Optional) List of container names this container can communicate with without port mappings | `list(string)` | `null` | no |
+| linux\_parameters | Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html | <pre>object({<br>    capabilities = object({<br>      add  = list(string)<br>      drop = list(string)<br>    })<br>    devices = list(object({<br>      containerPath = string<br>      hostPath      = string<br>      permissions   = list(string)<br>    }))<br>    initProcessEnabled = bool<br>    maxSwap            = number<br>    sharedMemorySize   = number<br>    swappiness         = number<br>    tmpfs = list(object({<br>      containerPath = string<br>      mountOptions  = list(string)<br>      size          = number<br>    }))<br>  })</pre> | `null` | no |
+| log\_configuration | (Optional) Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html | <pre>object({<br>    logDriver = string<br>    options   = map(string)<br>    secretOptions = list(object({<br>      name      = string<br>      valueFrom = string<br>    }))<br>  })</pre> | `null` | no |
+| mount\_points | (Optional) Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | <pre>list(object({<br>    containerPath = string<br>    sourceVolume  = string<br>  }))</pre> | `[]` | no |
+| name\_prefix | Name prefix for resources on AWS | `any` | n/a | yes |
+| placement\_constraints | (Optional) A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement\_constraints is 10. This is a list of maps, where each map should contain "type" and "expression" | `list` | `[]` | no |
+| port\_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | <pre>list(object({<br>    containerPort = number<br>    hostPort      = number<br>    protocol      = string<br>  }))</pre> | <pre>[<br>  {<br>    "containerPort": 80,<br>    "hostPort": 80,<br>    "protocol": "tcp"<br>  }<br>]</pre> | no |
+| proxy\_configuration | (Optional) The proxy configuration details for the App Mesh proxy. This is a list of maps, where each map should contain "container\_name", "properties" and "type" | `list` | `[]` | no |
+| readonly\_root\_filesystem | (Optional) Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `false` | no |
+| repository\_credentials | (Optional) Container repository credentials; required when using a private repo.  This map currently supports a single key; "credentialsParameter", which should be the ARN of a Secrets Manager's secret holding the credentials | `map(string)` | `null` | no |
+| secrets | (Optional) The secrets to pass to the container. This is a list of maps | <pre>list(object({<br>    name      = string<br>    valueFrom = string<br>  }))</pre> | `null` | no |
+| start\_timeout | (Optional) Time duration (in seconds) to wait before giving up on resolving dependencies for a container. | `number` | `30` | no |
+| stop\_timeout | (Optional) Timeout in seconds between sending SIGTERM and SIGKILL to container | `number` | `30` | no |
+| system\_controls | (Optional) A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = "", value = ""} | `list(map(string))` | `null` | no |
+| task\_role\_arn | (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services. If not specified, `aws_iam_role.ecs_task_execution_role.arn` is used | `string` | `null` | no |
+| ulimits | (Optional) Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | <pre>list(object({<br>    name      = string<br>    hardLimit = number<br>    softLimit = number<br>  }))</pre> | `null` | no |
+| user | (Optional) The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group | `string` | `null` | no |
+| volumes | (Optional) A set of volume blocks that containers in your task may use | <pre>list(object({<br>    host_path = string<br>    name      = string<br>    docker_volume_configuration = list(object({<br>      autoprovision = bool<br>      driver        = string<br>      driver_opts   = map(string)<br>      labels        = map(string)<br>      scope         = string<br>    }))<br>    efs_volume_configuration = list(object({<br>      file_system_id = string<br>      root_directory = string<br>    }))<br>  }))</pre> | `[]` | no |
+| volumes\_from | (Optional) A list of VolumesFrom maps which contain "sourceContainer" (name of the container that has the volumes to mount) and "readOnly" (whether the container can write to the volume) | <pre>list(object({<br>    sourceContainer = string<br>    readOnly        = bool<br>  }))</pre> | `null` | no |
+| working\_directory | (Optional) The working directory to run commands inside the container | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| aws\_ecs\_task\_definition\_td\_arn | Full ARN of the Task Definition (including both family and revision). |
+| aws\_ecs\_task\_definition\_td\_family | The family of the Task Definition. |
+| aws\_ecs\_task\_definition\_td\_revision | The revision of the task in a particular family. |
+| aws\_iam\_role\_ecs\_task\_execution\_role\_arn | The Amazon Resource Name (ARN) specifying the role. |
+| aws\_iam\_role\_ecs\_task\_execution\_role\_create\_date | The creation date of the IAM role. |
+| aws\_iam\_role\_ecs\_task\_execution\_role\_description | The description of the role. |
+| aws\_iam\_role\_ecs\_task\_execution\_role\_id | The ID of the role. |
+| aws\_iam\_role\_ecs\_task\_execution\_role\_name | The name of the role. |
+| aws\_iam\_role\_ecs\_task\_execution\_role\_unique\_id | The stable and unique string identifying the role. |
+| container\_name | Name of the container |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ module "container_definition" {
 # Task Definition
 resource "aws_ecs_task_definition" "td" {
   family                = "${var.name_prefix}-td"
-  container_definitions = "[ ${module.container_definition.json_map_object} ]"
+  container_definitions = "[${module.container_definition.json_map_encoded}]"
   task_role_arn         = var.task_role_arn == null ? aws_iam_role.ecs_task_execution_role.arn : var.task_role_arn
   execution_role_arn    = aws_iam_role.ecs_task_execution_role.arn
   network_mode          = "awsvpc"

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "environment" {
     name  = string
     value = string
   }))
-  default = null
+  default = []
 }
 
 variable "essential" {
@@ -158,7 +158,7 @@ variable "mount_points" {
     containerPath = string
     sourceVolume  = string
   }))
-  default = null
+  default = []
 }
 
 variable "port_mappings" {


### PR DESCRIPTION
1. Fix the problem with the default `null` value for `environment` and `mount_points` variables when using the module. I changed the default value for both variables from `null` to `[]`
When I tried to use the module before the fix I got an error:
```
Error: Invalid function argument

  on .terraform/modules/td.container_definition/main.tf line 17, in locals:
  17:   mount_points = length(var.mount_points) > 0 ? [
    |----------------
    | var.mount_points is null

Invalid value for "value" parameter: argument must not be null.

```

2. Fixed container definition value. I updated the module regarding this release https://github.com/cloudposse/terraform-aws-ecs-container-definition/releases/tag/0.38.0
Before fix I got an error:
```
Error: Invalid template interpolation value

  on ../../main.tf line 56, in resource "aws_ecs_task_definition" "td":
  56:   container_definitions = "[ ${module.container_definition.json_map_object} ]"
    |----------------
    | module.container_definition.json_map_object is object with 11 attributes

Cannot include the given value in a string template: string required.
```

3. Add auto-generation README.md and pre-commit hooks for formatting code and generate docs. Pre-commit docs: https://pre-commit.com/#install