### PR TITLE
Allow user to configure custom IAM policy for ECS Task Execution role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,20 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_attach
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_iam_policy" "ecs_task_execution_role_custom_policy" {
+  count = length(var.ecs_task_execution_role_custom_policy) > 0 ? 1 : 0
+  name        = "${var.name_prefix}-ecs-task-execution-role-custom-policy"
+  description = "A custom policy for ${var.name_prefix}-ecs-task-execution-role IAM Role"
+
+  policy = var.ecs_task_execution_role_custom_policy
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_custom_policy" {
+  count = length(var.ecs_task_execution_role_custom_policy) > 0 ? 1 : 0
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_task_execution_role_custom_policy[*].arn
+}
+
 #------------------------------------------------------------------------------
 # ECS Task Definition
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -322,6 +322,12 @@ variable "task_role_arn" {
   default     = null
 }
 
+variable "ecs_task_execution_role_custom_policy" {
+  description = "(Optional) A custom policy to attach to the ECS task execution role. For example for reading secrets from AWS Systems Manager Parameter Store or Secrets Manager"
+  type = string
+  default = null
+}
+
 variable "placement_constraints" {
   description = "(Optional) A set of placement constraints rules that are taken into consideration during task placement. Maximum number of placement_constraints is 10. This is a list of maps, where each map should contain \"type\" and \"expression\""
   type        = list
@@ -353,3 +359,4 @@ variable "volumes" {
   }))
   default = []
 }
+


### PR DESCRIPTION
In our use case, we need to configure a custom policy to be able to read AWS SSM Parameter Store and decrypt them with KMS.

This PR allows a user to define an IAM policy in variable `ecs_task_execution_role_custom_policy` and it will be attached to the IAM role `ecs_task_execution_role`.