### PR TITLE
Replace for_each with count for producing ECS custom policies.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,17 +14,17 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_attach
 }
 
 resource "aws_iam_policy" "ecs_task_execution_role_custom_policy" {
-  for_each    = { for s in var.ecs_task_execution_role_custom_policies : index(var.ecs_task_execution_role_custom_policies, s) => s }
-  name        = "${var.name_prefix}-ecs-task-execution-role-custom-policy-${each.key}"
+  count       = length(var.ecs_task_execution_role_custom_policies)
+  name        = "${var.name_prefix}-ecs-task-execution-role-custom-policy-${count.index}"
   description = "A custom policy for ${var.name_prefix}-ecs-task-execution-role IAM Role"
-  policy      = each.value
+  policy      = var.ecs_task_execution_role_custom_policies[count.index]
   tags        = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_custom_policy" {
-  for_each   = aws_iam_policy.ecs_task_execution_role_custom_policy
+  count      = length(var.ecs_task_execution_role_custom_policies)
   role       = aws_iam_role.ecs_task_execution_role.name
-  policy_arn = each.value.arn
+  policy_arn = aws_iam_policy.ecs_task_execution_role_custom_policy[count.index].arn
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Current approach using `for_each` doesn't work if a policy contains reference to resource. In this case it throws the following error:

```
Error: Invalid for_each argument
│
│   on .terraform/modules/td/main.tf line 17, in resource "aws_iam_policy" "ecs_task_execution_role_custom_policy":
│   17:   for_each    = { for s in var.ecs_task_execution_role_custom_policies : index(var.ecs_task_execution_role_custom_policies, s) => s }
│     ├────────────────
│     │ var.ecs_task_execution_role_custom_policies is list of string with 1 element
│
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of
│ this resource.
```

Looks like `for_each` in this case isn't really necessary as it's used only to convert a list to index => value map. And that's what `count` imitate as well. 