### PR TITLE
Allow Task and Execution roles as inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,6 +233,9 @@ Temporary Items
 # Local .terraform directories
 **/.terraform/*
 
+# Terraform lock file
+.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,21 @@
+fail_fast: true
+
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.71.0
+    rev: v1.77.1 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
-      - id: terraform_docs
       - id: terraform_fmt
+      - id: terraform_docs
+        args: ["--args=--lockfile=false"]
       - id: terraform_validate
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0 # Get the latest from: https://github.com/pre-commit/pre-commit-hooks/releases
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: detect-private-key
+      - id: check-yaml
+        files: ^(.github/workflows).*$

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,7 +65,7 @@ Additionally, community organizers are available to help community members engag
 
 ## 8. Addressing Grievances
 
-If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify CN Services with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies. 
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify CN Services with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies.
 
 
 
@@ -81,7 +81,7 @@ noninojulian@gmail.com
 
 ## 11. License and attribution
 
-The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
+The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
 
 Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Pleas run this command right after cloning the repository.
 
         pre-commit install
 
-For that you may need to install the folowwing tools:
-* [Pre-commit](https://pre-commit.com/) 
+For that you may need to install the following tools:
+* [Pre-commit](https://pre-commit.com/)
 * [Terraform Docs](https://terraform-docs.io/)
 
 In order to run all checks at any point run the following command:
@@ -35,19 +35,19 @@ In order to run all checks at any point run the following command:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_container_definition"></a> [container\_definition](#module\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.58.1 |
+| <a name="module_container_definition"></a> [container\_definition](#module\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.58.2 |
 
 ## Resources
 
@@ -83,6 +83,7 @@ In order to run all checks at any point run the following command:
 | <a name="input_environment_files"></a> [environment\_files](#input\_environment\_files) | One or more files containing the environment variables to pass to the container. This maps to the --env-file option to docker run. The file must be hosted in Amazon S3. This option is only available to tasks using the EC2 launch type. This is a list of maps | <pre>list(object({<br>    value = string<br>    type  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_ephemeral_storage_size"></a> [ephemeral\_storage\_size](#input\_ephemeral\_storage\_size) | The number of GBs to provision for ephemeral storage on Fargate tasks. Must be greater than or equal to 21 and less than or equal to 200 | `number` | `0` | no |
 | <a name="input_essential"></a> [essential](#input\_essential) | Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value | `bool` | `true` | no |
+| <a name="input_execution_role_arn"></a> [execution\_role\_arn](#input\_execution\_role\_arn) | (Optional) The ARN of IAM role that grants permissions to start the containers defined in a task (e.g populate environment variables from AWS Secrets Manager). If not specified, `aws_iam_role.ecs_task_execution_role.arn` is used | `string` | `null` | no |
 | <a name="input_extra_hosts"></a> [extra\_hosts](#input\_extra\_hosts) | A list of hostnames and IP address mappings to append to the /etc/hosts file on the container. This is a list of maps | <pre>list(object({<br>    ipAddress = string<br>    hostname  = string<br>  }))</pre> | `null` | no |
 | <a name="input_firelens_configuration"></a> [firelens\_configuration](#input\_firelens\_configuration) | The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html | <pre>object({<br>    type    = string<br>    options = map(string)<br>  })</pre> | `null` | no |
 | <a name="input_healthcheck"></a> [healthcheck](#input\_healthcheck) | (Optional) A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | <pre>object({<br>    command     = list(string)<br>    retries     = number<br>    timeout     = number<br>    interval    = number<br>    startPeriod = number<br>  })</pre> | `null` | no |
@@ -115,7 +116,7 @@ In order to run all checks at any point run the following command:
 | <a name="input_stop_timeout"></a> [stop\_timeout](#input\_stop\_timeout) | Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own | `number` | `null` | no |
 | <a name="input_system_controls"></a> [system\_controls](#input\_system\_controls) | A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = "", value = ""} | `list(map(string))` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags | `map(string)` | `{}` | no |
-| <a name="input_task_role_arn"></a> [task\_role\_arn](#input\_task\_role\_arn) | (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services. If not specified, `aws_iam_role.ecs_task_execution_role.arn` is used | `string` | `null` | no |
+| <a name="input_task_role_arn"></a> [task\_role\_arn](#input\_task\_role\_arn) | (Optional) The ARN of IAM role that grants permissions to the actual application once the container is started (e.g access an S3 bucket or DynamoDB database). If not specified, `aws_iam_role.ecs_task_execution_role.arn` is used | `string` | `null` | no |
 | <a name="input_ulimits"></a> [ulimits](#input\_ulimits) | Container ulimit settings. This is a list of maps, where each map should contain "name", "hardLimit" and "softLimit" | <pre>list(object({<br>    name      = string<br>    hardLimit = number<br>    softLimit = number<br>  }))</pre> | `null` | no |
 | <a name="input_user"></a> [user](#input\_user) | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set. | `string` | `null` | no |
 | <a name="input_volumes"></a> [volumes](#input\_volumes) | (Optional) A set of volume blocks that containers in your task may use | <pre>list(object({<br>    host_path = string<br>    name      = string<br>    docker_volume_configuration = list(object({<br>      autoprovision = bool<br>      driver        = string<br>      driver_opts   = map(string)<br>      labels        = map(string)<br>      scope         = string<br>    }))<br>    efs_volume_configuration = list(object({<br>      file_system_id          = string<br>      root_directory          = string<br>      transit_encryption      = string<br>      transit_encryption_port = string<br>      authorization_config = list(object({<br>        access_point_id = string<br>        iam             = string<br>      }))<br>    }))<br>  }))</pre> | `[]` | no |

--- a/examples/test/.terraform.lock.hcl
+++ b/examples/test/.terraform.lock.hcl
@@ -8,6 +8,7 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:G0toIzBkhRr/UNRdksvnIyPXnGT9nH0A7gWmu93I1Eg=",
     "h1:StwpoFw0rXHgAVGV1M/QZaN9OfGx/3+mo1EjjFpbu9w=",
     "h1:XjvC5UMR+bRj8Rt9T2VhJdryCfe6lxDaXUSOKFviV5c=",
+    "h1:wHydn6CP2wkxUfcq4nRw2NdCc4+rERltXaNZ97U0zAo=",
     "zh:02937cb37860b022e7d996726e7584ca23904baf7852d266f2dd7891ee088ae4",
     "zh:259dd5790ec5f4e6814c9584c79834dce3d719e932ce662b21f13434e9441194",
     "zh:2d230c8c92c3cb2c07471a4324d802c44365dcf99fe0d562cc737d1f964e9c1d",
@@ -19,26 +20,5 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:b16a622a76bee455c8b256d828f8a60515e1e9dad38420a4db1be9b9e16d474a",
     "zh:c805822f0ba57e8063b6201e1f351aa4dbd5ad8886dedd25d809e5aeb9aa0259",
     "zh:e1c3a0da5576aec4a48f897cd04b739c1f533cdb0005ce4c7f5bc45808b799b1",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/local" {
-  version     = "2.1.0"
-  constraints = ">= 1.2.0"
-  hashes = [
-    "h1:/OpJKWupvFd8WJX1mTt8vi01pP7dkA6e//4l4C3TExE=",
-    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
-    "h1:PaQTpxHMbZB9XV+c1od1eaUvndQle3ZZHx79hrI6C3k=",
-    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
-    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
-    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
-    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
-    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
-    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
-    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
-    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
-    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
-    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
-    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_attach" {
   count      = var.execution_role_arn == null ? 1 : 0
-  role       = aws_iam_role.ecs_task_execution_role[*].name
+  role       = aws_iam_role.ecs_task_execution_role[0].name
   policy_arn = "arn:${var.iam_partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
@@ -25,7 +25,7 @@ resource "aws_iam_policy" "ecs_task_execution_role_custom_policy" {
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_custom_policy" {
   count      = var.execution_role_arn == null ? length(var.ecs_task_execution_role_custom_policies) : 0
-  role       = aws_iam_role.ecs_task_execution_role[*].name
+  role       = aws_iam_role.ecs_task_execution_role[0].name
   policy_arn = aws_iam_policy.ecs_task_execution_role_custom_policy[count.index].arn
 }
 
@@ -87,8 +87,8 @@ resource "aws_ecs_task_definition" "td" {
   family                = var.name_prefix
 
   cpu                = var.container_cpu
-  task_role_arn      = var.task_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].arn : var.task_role_arn
-  execution_role_arn = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].arn : var.execution_role_arn
+  task_role_arn      = var.task_role_arn == null ? aws_iam_role.ecs_task_execution_role[0].arn : var.task_role_arn
+  execution_role_arn = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[0].arn : var.execution_role_arn
   ipc_mode           = var.ipc_mode
   memory             = var.container_memory
   network_mode       = "awsvpc" # awsvpc required for Fargate tasks

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@
 # AWS ECS Task Execution Role
 #------------------------------------------------------------------------------
 resource "aws_iam_role" "ecs_task_execution_role" {
+  count                = var.execution_role_arn == null ? 1 : 0
   name                 = "${var.name_prefix}-ecs-task-execution-role"
   assume_role_policy   = file("${path.module}/files/iam/ecs_task_execution_iam_role.json")
   permissions_boundary = var.permissions_boundary
@@ -9,12 +10,13 @@ resource "aws_iam_role" "ecs_task_execution_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_attach" {
-  role       = aws_iam_role.ecs_task_execution_role.name
+  count      = var.execution_role_arn == null ? 1 : 0
+  role       = aws_iam_role.ecs_task_execution_role[*].name
   policy_arn = "arn:${var.iam_partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
 resource "aws_iam_policy" "ecs_task_execution_role_custom_policy" {
-  count       = length(var.ecs_task_execution_role_custom_policies)
+  count       = var.execution_role_arn == null ? length(var.ecs_task_execution_role_custom_policies) : 0
   name        = "${var.name_prefix}-ecs-task-execution-role-custom-policy-${count.index}"
   description = "A custom policy for ${var.name_prefix}-ecs-task-execution-role IAM Role"
   policy      = var.ecs_task_execution_role_custom_policies[count.index]
@@ -22,8 +24,8 @@ resource "aws_iam_policy" "ecs_task_execution_role_custom_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_custom_policy" {
-  count      = length(var.ecs_task_execution_role_custom_policies)
-  role       = aws_iam_role.ecs_task_execution_role.name
+  count      = var.execution_role_arn == null ? length(var.ecs_task_execution_role_custom_policies) : 0
+  role       = aws_iam_role.ecs_task_execution_role[*].name
   policy_arn = aws_iam_policy.ecs_task_execution_role_custom_policy[count.index].arn
 }
 
@@ -85,7 +87,8 @@ resource "aws_ecs_task_definition" "td" {
   family                = var.name_prefix
 
   cpu                = var.container_cpu
-  execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn      = var.task_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].arn : var.task_role_arn
+  execution_role_arn = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].arn : var.execution_role_arn
   ipc_mode           = var.ipc_mode
   memory             = var.container_memory
   network_mode       = "awsvpc" # awsvpc required for Fargate tasks
@@ -123,7 +126,6 @@ resource "aws_ecs_task_definition" "td" {
 
   requires_compatibilities = ["FARGATE"]
   skip_destroy             = var.skip_destroy
-  task_role_arn            = var.task_role_arn == null ? aws_iam_role.ecs_task_execution_role.arn : var.task_role_arn
 
   dynamic "volume" {
     for_each = var.volumes

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,32 +3,32 @@
 #------------------------------------------------------------------------------
 output "aws_iam_role_ecs_task_execution_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the role."
-  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].arn : var.execution_role_arn
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[0].arn : var.execution_role_arn
 }
 
 output "aws_iam_role_ecs_task_execution_role_create_date" {
   description = "The creation date of the IAM role."
-  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].create_date : null
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[0].create_date : null
 }
 
 output "aws_iam_role_ecs_task_execution_role_description" {
   description = "The description of the role."
-  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].description : null
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[0].description : null
 }
 
 output "aws_iam_role_ecs_task_execution_role_id" {
   description = "The ID of the role."
-  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].id : null
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[0].id : null
 }
 
 output "aws_iam_role_ecs_task_execution_role_name" {
   description = "The name of the role."
-  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].name : null
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[0].name : null
 }
 
 output "aws_iam_role_ecs_task_execution_role_unique_id" {
   description = "The stable and unique string identifying the role."
-  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].unique_id : null
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[0].unique_id : null
 }
 
 #------------------------------------------------------------------------------

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,27 +3,32 @@
 #------------------------------------------------------------------------------
 output "aws_iam_role_ecs_task_execution_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the role."
-  value       = aws_iam_role.ecs_task_execution_role.arn
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].arn : var.execution_role_arn
 }
+
 output "aws_iam_role_ecs_task_execution_role_create_date" {
   description = "The creation date of the IAM role."
-  value       = aws_iam_role.ecs_task_execution_role.create_date
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].create_date : null
 }
+
 output "aws_iam_role_ecs_task_execution_role_description" {
   description = "The description of the role."
-  value       = aws_iam_role.ecs_task_execution_role.description
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].description : null
 }
+
 output "aws_iam_role_ecs_task_execution_role_id" {
   description = "The ID of the role."
-  value       = aws_iam_role.ecs_task_execution_role.id
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].id : null
 }
+
 output "aws_iam_role_ecs_task_execution_role_name" {
   description = "The name of the role."
-  value       = aws_iam_role.ecs_task_execution_role.name
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].name : null
 }
+
 output "aws_iam_role_ecs_task_execution_role_unique_id" {
   description = "The stable and unique string identifying the role."
-  value       = aws_iam_role.ecs_task_execution_role.unique_id
+  value       = var.execution_role_arn == null ? aws_iam_role.ecs_task_execution_role[*].unique_id : null
 }
 
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -433,7 +433,13 @@ variable "skip_destroy" {
 }
 
 variable "task_role_arn" {
-  description = "(Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services. If not specified, `aws_iam_role.ecs_task_execution_role.arn` is used"
+  description = "(Optional) The ARN of IAM role that grants permissions to the actual application once the container is started (e.g access an S3 bucket or DynamoDB database). If not specified, `aws_iam_role.ecs_task_execution_role.arn` is used"
+  type        = string
+  default     = null
+}
+
+variable "execution_role_arn" {
+  description = "(Optional) The ARN of IAM role that grants permissions to start the containers defined in a task (e.g populate environment variables from AWS Secrets Manager). If not specified, `aws_iam_role.ecs_task_execution_role.arn` is used"
   type        = string
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4"
+      version = ">= 4.0.0"
     }
   }
 }


### PR DESCRIPTION
Allow the module to accept ECS Task Execution Role and ECS Task Role ARNs as input variables, disabling the creation of the `aws_iam_role.ecs_task_execution_role` resource and the custom policies.

Additionally, I removed the `.terraform.lock.hcl` files and did some adjustments to `pre-commit` hooks.